### PR TITLE
Added ChatStyle

### DIFF
--- a/lib/models/chat_style.dart
+++ b/lib/models/chat_style.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class ChatStyle {
+  final Color mainColor;
+  final Color visitorColor;
+  final TextStyle nameTextStyle;
+  final TextStyle messageTextStyle;
+
+  const ChatStyle({
+    this.mainColor,
+    this.visitorColor,
+    this.nameTextStyle,
+    this.messageTextStyle,
+  });
+
+  ChatStyle copyWith({
+    Color mainColor,
+    Color visitorColor,
+    TextStyle nameTextStyle,
+    TextStyle messageTextStyle,
+  }) {
+    return ChatStyle(
+      mainColor: mainColor ?? this.mainColor,
+      visitorColor: visitorColor ?? this.visitorColor,
+      nameTextStyle: nameTextStyle ?? this.nameTextStyle,
+      messageTextStyle: messageTextStyle ?? this.messageTextStyle,
+    );
+  }
+}

--- a/lib/widgets/zendesk_chat_widget.dart
+++ b/lib/widgets/zendesk_chat_widget.dart
@@ -1,35 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:zendesk_chat/models/chat_settings_model.dart';
+import 'package:zendesk_chat/models/chat_style.dart';
 import 'package:zendesk_flutter_plugin/chat_models.dart';
 import 'package:zendesk_flutter_plugin/zendesk_flutter_plugin.dart';
 
-class ChatStyle {
-  final Color mainColor;
-  final Color visitorColor;
-  final TextStyle nameTextStyle;
-  final TextStyle descriptionTextStyle;
 
-  const ChatStyle({
-    this.mainColor,
-    this.visitorColor,
-    this.nameTextStyle,
-    this.descriptionTextStyle,
-  });
-
-  ChatStyle copyWith({
-    Color mainColor,
-    Color visitorColor,
-    TextStyle nameTextStyle,
-    TextStyle descriptionTextStyle,
-  }) {
-    return ChatStyle(
-      mainColor: mainColor ?? this.mainColor,
-      visitorColor: visitorColor ?? this.visitorColor,
-      nameTextStyle: nameTextStyle ?? this.nameTextStyle,
-      descriptionTextStyle: descriptionTextStyle ?? this.descriptionTextStyle,
-    );
-  }
-}
 
 class _DefaultStyle extends ChatStyle {
   final Color mainColor = Colors.blue;
@@ -39,7 +14,7 @@ class _DefaultStyle extends ChatStyle {
     color: Colors.white,
   );
 
-  final TextStyle descriptionTextStyle = const TextStyle(
+  final TextStyle messageTextStyle = const TextStyle(
     color: Colors.white,
   );
 
@@ -47,7 +22,7 @@ class _DefaultStyle extends ChatStyle {
     Color mainColor,
     Color visitorColor,
     TextStyle nameTextStyle,
-    TextStyle descriptionTextStyle,
+    TextStyle messageTextStyle,
   });
 }
 
@@ -155,7 +130,7 @@ class _ZendeskChatWidgetState extends State<ZendeskChatWidget> {
                   ),
                   Text(
                     chatItem?.message ?? '',
-                    style: chatStyle.descriptionTextStyle,
+                    style: chatStyle.messageTextStyle,
                   ),
                 ],
               )

--- a/lib/widgets/zendesk_chat_widget.dart
+++ b/lib/widgets/zendesk_chat_widget.dart
@@ -3,14 +3,66 @@ import 'package:zendesk_chat/models/chat_settings_model.dart';
 import 'package:zendesk_flutter_plugin/chat_models.dart';
 import 'package:zendesk_flutter_plugin/zendesk_flutter_plugin.dart';
 
+class ChatStyle {
+  final Color mainColor;
+  final Color visitorColor;
+  final TextStyle nameTextStyle;
+  final TextStyle descriptionTextStyle;
+
+  const ChatStyle({
+    this.mainColor,
+    this.visitorColor,
+    this.nameTextStyle,
+    this.descriptionTextStyle,
+  });
+
+  ChatStyle copyWith({
+    Color mainColor,
+    Color visitorColor,
+    TextStyle nameTextStyle,
+    TextStyle descriptionTextStyle,
+  }) {
+    return ChatStyle(
+      mainColor: mainColor ?? this.mainColor,
+      visitorColor: visitorColor ?? this.visitorColor,
+      nameTextStyle: nameTextStyle ?? this.nameTextStyle,
+      descriptionTextStyle: descriptionTextStyle ?? this.descriptionTextStyle,
+    );
+  }
+}
+
+class _DefaultStyle extends ChatStyle {
+  final Color mainColor = Colors.blue;
+  final Color visitorColor = Colors.green;
+  final TextStyle nameTextStyle = const TextStyle(
+    fontWeight: FontWeight.bold,
+    color: Colors.white,
+  );
+
+  final TextStyle descriptionTextStyle = const TextStyle(
+    color: Colors.white,
+  );
+
+  const _DefaultStyle({
+    Color mainColor,
+    Color visitorColor,
+    TextStyle nameTextStyle,
+    TextStyle descriptionTextStyle,
+  });
+}
+
+const ChatStyle _defaultStyle = const _DefaultStyle();
+
 class ZendeskChatWidget extends StatefulWidget {
   final ChatSettings chatSettings;
   final ZendeskFlutterPlugin zendeskSdk;
+  final ChatStyle chatStyle;
 
   const ZendeskChatWidget({
     Key key,
     @required this.zendeskSdk,
     @required this.chatSettings,
+    this.chatStyle = _defaultStyle,
   })  : assert(chatSettings != null),
         assert(zendeskSdk != null),
         super(key: key);
@@ -22,8 +74,12 @@ class ZendeskChatWidget extends StatefulWidget {
 class _ZendeskChatWidgetState extends State<ZendeskChatWidget> {
   ConnectionStatus _connectionStatus;
   List<ChatItem> _chatLog = [];
+
   ChatSettings get chatSettings => widget.chatSettings;
+
   ZendeskFlutterPlugin get zendeskSdk => widget.zendeskSdk;
+
+  ChatStyle get chatStyle => widget.chatStyle;
 
   final msgController = TextEditingController();
 
@@ -67,11 +123,11 @@ class _ZendeskChatWidgetState extends State<ZendeskChatWidget> {
 
   Widget mapChatLogToMessage(ChatItem chatItem) {
     MainAxisAlignment alignment = MainAxisAlignment.start;
-    Color color = Theme.of(context).primaryColor;
+    Color color = chatStyle.mainColor;
 
     if (chatItem.nick.startsWith('visitor')) {
       alignment = MainAxisAlignment.end;
-      color = Theme.of(context).accentColor;
+      color = chatStyle.visitorColor;
     }
 
     return Row(
@@ -94,17 +150,12 @@ class _ZendeskChatWidgetState extends State<ZendeskChatWidget> {
                     margin: EdgeInsets.only(bottom: 5),
                     child: Text(
                       chatItem?.displayName,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
-                      ),
+                      style: chatStyle.nameTextStyle,
                     ),
                   ),
                   Text(
                     chatItem?.message ?? '',
-                    style: TextStyle(
-                      color: Colors.white,
-                    ),
+                    style: chatStyle.descriptionTextStyle,
                   ),
                 ],
               )


### PR DESCRIPTION
Fixes #5 
Added customisable chat style.

You can create styles and use the `copyWith()` to change some parameters for example:

![image](https://user-images.githubusercontent.com/23307893/67003031-6ab20100-f0dd-11e9-90b4-f9998c1880f7.png)

For example in this case the secondary style will get all the main style with the main color changed